### PR TITLE
Refactor: migrate container build to multi-stage Dockerfile with secret mounts

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -30,26 +30,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Start Wolfram Engine Container
-        run: |
-          docker run -d --name wolfram \
-            -v $GITHUB_WORKSPACE:/workspace \
-            -w /workspace \
-            wolframresearch/wolframengine:14.2 tail -f /dev/null
-
-      - name: Fix permissions for /workspace directory at host level
-        run: |
-          sudo chmod -R 777 $GITHUB_WORKSPACE
-
-      - name: Install ffmpeg inside Wolfram container
-        run: |
-          docker exec --user root wolfram bash -c "apt-get update && apt-get install -y ffmpeg"
-
-      - name: Fetch all dependencies inside Wolfram container
-        run: |
-          docker exec -e WOLFRAMSCRIPT_ENTITLEMENTID=${{ secrets.WOLFRAM_LICENSE_ENTITLEMENT_ID }} wolfram \
-          wolframscript -script ./Scripts/update.wls
-
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -62,6 +42,8 @@ jobs:
         with:
           context: .
           file: "./container/Containerfile"
+          secrets: |
+            "wolfram_license=${{ secrets.WOLFRAM_LICENSE_ENTITLEMENT_ID }}"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,4 +1,17 @@
-FROM docker.io/wolframresearch/wolframengine
+# syntax=docker/dockerfile:1
+FROM docker.io/wolframresearch/wolframengine AS deps
+
+RUN apt-get update && apt-get install -y ffmpeg
+
+COPY Scripts/update.wls /workspace/Scripts/update.wls
+COPY Common/ /workspace/Common/
+
+WORKDIR /workspace
+
+RUN --mount=type=secret,id=wolfram_license,env=WOLFRAMSCRIPT_ENTITLEMENTID,required=true wolframscript -script Scripts/update.wls
+
+
+FROM wolframresearch/wolframengine:14.2 AS final
 
 USER root
 
@@ -6,23 +19,25 @@ RUN useradd -m wljs
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+COPY --from=deps /workspace/wl_packages /wljs/wl_packages  
+COPY --from=deps /workspace/wljs_packages /wljs/wljs_packages
+
+COPY ./ /wljs/
+COPY container/run.sh /usr/local/bin/run.sh
+
+COPY container/wljs-routes /etc/nginx/sites-available/default
+COPY container/proxy-snippet.conf /etc/nginx/snippets/proxy.conf
+
 RUN apt-get update && apt-get install -y \
     git \
     nginx \
     expect \
     curl \
+    ffmpeg \
  && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
  && apt-get install -y nodejs \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && chmod +x /usr/local/bin/run.sh
 
-COPY container/wljs-routes /etc/nginx/sites-available/default
-COPY container/proxy-snippet.conf /etc/nginx/snippets/proxy.conf
-
-RUN mkdir -p /wljs
-COPY ./ /wljs/
-
-COPY container/run.sh /run.sh
-RUN chmod +x /run.sh
-
-CMD /run.sh
+CMD ["/usr/local/bin/run.sh"]


### PR DESCRIPTION
As I proposed in the discussion, here is the change to implement multi-stage build to build the container. The building precess is done in a single Containerfile.

The Containerfile contains two stages:

1. It uses `docker.io/wolframresearch/wolframengine` image to fetch all dependencies.
2. It uses `wolframresearch/wolframengine:14.2` as the base image and copies all dependencies from the first container. 

As I do not have the license, I cannot test this by myself, so this is a draft PR.